### PR TITLE
Non index pages

### DIFF
--- a/pagebreak/features/pagination-urls.feature
+++ b/pagebreak/features/pagination-urls.feature
@@ -4,8 +4,8 @@ Feature: Pagination URLs
     Given I have a "source/index.html" file with the body:
       """
       <section data-pagebreak="1" data-pagebreak-url="./pb/:num/j/">
-        <p>Item 1</p>
-        <p>Item 2</p>
+      <p>Item 1</p>
+      <p>Item 2</p>
       </section>
       """
     When I run Pagebreak
@@ -17,8 +17,8 @@ Feature: Pagination URLs
     Given I have a "source/red/blue/yellow/index.html" file with the body:
       """
       <section data-pagebreak="1" data-pagebreak-url="../../green/:num/">
-        <p>Item 1</p>
-        <p>Item 2</p>
+      <p>Item 1</p>
+      <p>Item 2</p>
       </section>
       """
     When I run Pagebreak
@@ -29,8 +29,8 @@ Feature: Pagination URLs
     Given I have a "source/index.html" file with the body:
       """
       <section data-pagebreak="1" data-pagebreak-url="./page/:num">
-        <p>Item 1</p>
-        <p>Item 2</p>
+      <p>Item 1</p>
+      <p>Item 2</p>
       </section>
       """
     When I run Pagebreak
@@ -39,14 +39,25 @@ Feature: Pagination URLs
     But I should not see the file "output/page/2.html"
 
   Scenario: If I provide a named HTML page, I should get a named pagination page
-    Given This should be implemented in issue #4
     Given I have a "source/about.html" file with the body:
       """
       <section data-pagebreak="1" data-pagebreak-url="./page/:num/">
-        <p>Item 1</p>
-        <p>Item 2</p>
+      <p>Item 1</p>
+      <p>Item 2</p>
       </section>
       """
     When I run Pagebreak
     Then I should see the file "output/about.html"
-    And I should see the file "output/about/page/2.html"
+    And I should see the file "output/about/page/2/index.html"
+
+  Scenario: If I provide a named HTML page without a trailing slash, I should get a named pagination page
+    Given I have a "source/about.html" file with the body:
+      """
+      <section data-pagebreak="1" data-pagebreak-url="./page/:num">
+      <p>Item 1</p>
+      <p>Item 2</p>
+      </section>
+      """
+    When I run Pagebreak
+    Then I should see the file "output/about.html"
+    And I should see the file "output/about/page/2/index.html"

--- a/pagebreak/features/pagination-urls.feature
+++ b/pagebreak/features/pagination-urls.feature
@@ -61,3 +61,4 @@ Feature: Pagination URLs
     When I run Pagebreak
     Then I should see the file "output/about.html"
     And I should see the file "output/about/page/2/index.html"
+    But I should not see the file "output/about/page/2.html"

--- a/pagebreak/src/state.rs
+++ b/pagebreak/src/state.rs
@@ -468,7 +468,12 @@ impl PagebreakState {
             _ => {
                 let page_number = (&page_number + 1).to_string();
                 let file_url = self.page_url_format.replace(":num", &page_number);
-                let file_path = PathBuf::from(file_url).join(self.file_path.file_name().unwrap());
+                let file_stem = self.file_path.file_stem().unwrap().to_str().unwrap();
+                let file_path = if !file_stem.eq("index") {
+                    PathBuf::from(file_stem).join(file_url).join("index.html")
+                } else {
+                    PathBuf::from(file_url).join("index.html")
+                };
                 let cleaned_path = self.file_path.parent().unwrap().join(file_path).clean();
 
                 match cleaned_path.components().next().unwrap() {


### PR DESCRIPTION
Fixes #4
I changed the spec a little bit because outputting to `output/about/page/2.html` seemed to be inconsistent with how we normally output, but I could be misunderstanding something.